### PR TITLE
changed some patterns on the pundit authorizations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   include Pundit
 
-  after_action :verify_authorized, except: [ :index, :show ], unless: :skip_pundit?
+  after_action :verify_authorized, except: :index, unless: :skip_pundit?
   # after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
 
   # Uncomment when you *really understand* Pundit!

--- a/app/controllers/campsites_controller.rb
+++ b/app/controllers/campsites_controller.rb
@@ -1,5 +1,6 @@
 class CampsitesController < ApplicationController
   skip_before_action :authenticate_user!, only: [ :index, :show ]
+  skip_after_action :verify_authorized, only: [ :show ]
 
   def index
     @campsites = Campsite.all


### PR DESCRIPTION
Morning, everyone! I have a few suggestions on how we can standardize our way of writing some Pundit/Devise.

**Devise**
This line comes on the ApplicationController:
`before_action :authenticate_user!`

And we do the skip_before_action on the specific controllers, for instance on the CampsitesController:
`skip_before_action :authenticate_user!, only: [ :index, :show ]`

**Pundit**
These lines come in the ApplicationController:
`after_action :verify_authorized, except: :index, unless: :skip_pundit?`
`after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?`

And we do the skip_after_action on the specific controllers, for instance on the CampsitesController:
`skip_after_action :verify_authorized, only: [ :show ]`

My suggestion is we go with `skip_after_action :verify_authorized` so we don't have to keep writing `skip authorization` on each method we might need to do so.

What do you think? Open to more suggestions!